### PR TITLE
Include whether a puzzle is streak eligible or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The NYT app shows minimal information around your streaks and average solve time
 
 Fetch all solve stats since January 1, 2019. Use your NYT email and passwords as arguments here
 ```bash
-python fetch_puzzle_stats -u your@email.com -p yourpass -s 2019-01-01
+python fetch_puzzle_stats.py -u your@email.com -p yourpass -s 2019-01-01
 ```
 
 The resulting CSV file (`data.csv` by default, override with `-o` flag) has your solve stats.
@@ -28,19 +28,19 @@ The resulting CSV file (`data.csv` by default, override with `-o` flag) has your
 ### Example CSV:
 (my real stats...don't judge me you pros out there...)
 ```csv
-date,day,elapsed_seconds,solved,checked,revealed
-2019-02-14,Thu,2107,1,0,0
-2019-02-15,Fri,2070,1,1,1
-2019-02-16,Sat,2365,1,0,0
-2019-02-17,Sun,0,0,0,0
+date,day,elapsed_seconds,solved,checked,revealed,streak_eligible
+2019-02-14,Thu,2107,1,0,0,1
+2019-02-15,Fri,2070,1,1,1,0
+2019-02-16,Sat,2365,1,0,0,1
+2019-02-17,Sun,0,0,0,0,0
 ```
 
-date | day | elapsed_seconds | solved | checked | revealed
---- | --- | --- | --- | --- | ---
-2019-02-14|Thu|2107|1|0|0
-2019-02-15|Fri|2070|1|1|1
-2019-02-16|Sat|2365|1|0|0
-2019-02-17|Sun|0|0|0|0
+date | day | elapsed_seconds | solved | checked | revealed | streak_eligible
+--- | --- | --- | --- | --- | --- | ---
+2019-02-14|Thu|2107|1|0|0|1
+2019-02-15|Fri|2070|1|1|1|0
+2019-02-16|Sat|2365|1|0|0|1
+2019-02-17|Sun|0|0|0|0|0
 
 
 ### Fields in CSV:
@@ -50,6 +50,7 @@ date | day | elapsed_seconds | solved | checked | revealed
 * **solved** - `1` if you finished/solved the puzzle, `0` otherwise
 * **checked** - `1` if you had to check an answer on the puzzle, thus making it ineligible for streaks
 * **revealed** - `1` if you had to reveal an answer on the puzzle, thus making it ineligible for streaks
+* **streak_eligible** - `1` if the puzzle counts towards your NYT streak - this means you solved without cheating (checks or reveals) on the day of the puzzle before Midnight PST
 
 ## Example
 


### PR DESCRIPTION
Fixes #1

This adds a field to the output data including whether a puzzle is eligible for a streak or not. Since this data isn't (apparently) exposed directly, it is inferred using the following rules:
 - The puzzle is solved
 - The solver did not reveal any answers
 - The solver did not check any answers
 - The solve happened before next day midnight PST (this is calculated as 8 hours before UTC and ignores DST. Technically for about 6 months/year you could solve the puzzle at 12:30 AM next day and get credit for it but I didn't want to go down the Python timezone rabbit hole for this)

I cross-referenced my results over the last few months and the streak eligibility lines up with what the NYT app reports. If you see a discrepancy open an issue here and let me know.