### PR TITLE
Hard code Mozilla User Agent

### DIFF
--- a/fetch_puzzle_stats.py
+++ b/fetch_puzzle_stats.py
@@ -45,6 +45,7 @@ def login(username, password):
             'password': password,
         },
         headers={
+            'User-Agent': 'Mozilla/5.0',
             'client_id': 'ios.crosswords',
         }
     )


### PR DESCRIPTION
This fixes #3

Apparently NYT started blocking (HTTP 403) requests with the Python requests User-Agent, so this makes it look like we're a browser.