### PR TITLE
V3 fix

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+NYT_COOKIE=PasteYourNYTCookieDataHere

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Fetch your NYT Crossword Puzzle solve stats and export them as CSV.
 
 The NYT app shows minimal information around your streaks and average solve times. This gets you the raw data so you can do your own analysis.
 
+This version is a departure from its predecessor and uses new API endpoints published by the NYT. The data it produces does not line up tidily with the previous version.
+
 ## What's a GitHub?
 Not well-versed in Python or the command-line? Consider signing up for [XW Stats](https://xwstats.com). It's a free site that automatically fetches your solves and allows you to download them as a CSV.
 
@@ -23,11 +25,23 @@ Fetch all solve stats since January 1, 2019. Use your NYT email and passwords as
 ```bash
 python fetch_puzzle_stats.py -u your@email.com -p yourpass -s 2019-01-01
 ```
+## Options
+
+Follow the command `python fetch_puzzle_stats.py` with these options if you want to:
+* `-u` or `--username` The email address for your NYT account
+* `-p` or `--password` The password for your NYT account
+* `-s` or `--start_date` The date to start fetching stats from (default: 30 days ago)
+* `-e` or `--end_date` The date to stop fetching stats from (default: today)
+* `-o` or `--output` The name of the CSV file to output (default: data.csv)
+* `-t` or `--type` The type of puzzle to fetch. One of "daily", "mini", or "bonus" (default: Daily)
 
 ### Login Issues
-* If you are experiencing 403 errors and you are sure your username and password are correct, you may need to provide your login cookie normally. Follow the [instruction steps here](https://xwstats.com/link) to get your cookie, then pass it as the `NYT_COOKIE` environment variable. For example:
+If you are experiencing 403 errors and you are _sure_ your username and password are correct, you may need to provide your login cookie manually. It's a two-step process: 
+
+1) Follow the [instruction steps here](https://xwstats.com/link) to get your cookie.
+2) Rename the file `.env.template` to `.env` and paste your cookie into it like this:
 ```
-NYT_COOKIE='1ELEHES...yDo40' python fetch_puzzle_stats.py -s '2019-01-01'
+NYT_COOKIE=1ELEHES...yDo40
 ```
 * If your e-mail or password have some unusual characters, be sure to escape them properly, or wrap the password in quotes (`'` or `"`).
 
@@ -38,29 +52,34 @@ The resulting CSV file (`data.csv` by default, override with `-o` flag) has your
 ### Example CSV:
 (my real stats...don't judge me you pros out there...)
 ```csv
-date,day,elapsed_seconds,solved,checked,revealed,streak_eligible
-2019-02-14,Thu,2107,1,0,0,1
-2019-02-15,Fri,2070,1,1,1,0
-2019-02-16,Sat,2365,1,0,0,1
-2019-02-17,Sun,0,0,0,0,0
+author,editor,format_type,print_date,day_of_week_name,day_of_week_integer,publish_type,puzzle_id,title,version,percent_filled,solved,star,solving_seconds
+Will Nediger,Will Shortz,Normal,2023-12-23,Saturday,6,Daily,21560,,0,100,True,Gold,675
+Drew Schmenner,Will Shortz,Normal,2023-12-24,Sunday,0,Daily,21568,Wrap Stars,0,100,True,Gold,1449
+Amie Walker,Will Shortz,Normal,2023-12-25,Monday,1,Daily,21567,,0,100,True,Gold,243
 ```
+| author         | editor      | format_type | print_date | day_of_week_name | day_of_week_integer | publish_type | puzzle_id | title      | version | percent_filled | solved | star | solving_seconds |
+|----------------|-------------|-------------|------------|------------------|---------------------|--------------|-----------|------------|---------|----------------|--------|------|-----------------|
+| Will Nediger   | Will Shortz | Normal      | 2023-12-23 | Saturday         | 6                   | Daily        | 21560     |            | 0       | 100            | True   | Gold | 675             |
+| Drew Schmenner | Will Shortz | Normal      | 2023-12-24 | Sunday           | 0                   | Daily        | 21568     | Wrap Stars | 0       | 100            | True   | Gold | 1449            |
+| Amie Walker    | Will Shortz | Normal      | 2023-12-25 | Monday           | 1                   | Daily        | 21567     |            | 0       | 100            | True   | Gold | 243             |
 
-date | day | elapsed_seconds | solved | checked | revealed | streak_eligible
---- | --- | --- | --- | --- | --- | ---
-2019-02-14|Thu|2107|1|0|0|1
-2019-02-15|Fri|2070|1|1|1|0
-2019-02-16|Sat|2365|1|0|0|1
-2019-02-17|Sun|0|0|0|0|0
+
 
 
 ### Fields in CSV:
-* **date** - The date the puzzle was published
-* **day** - The day the puzzle was published (e.g., "Mon", "Tue") - useful for comparing different difficulties
-* **elapsed** - How long it took you to solve the puzzle, in seconds
-* **solved** - `1` if you finished/solved the puzzle, `0` otherwise
-* **checked** - `1` if you had to check an answer on the puzzle, thus making it ineligible for streaks
-* **revealed** - `1` if you had to reveal an answer on the puzzle, thus making it ineligible for streaks
-* **streak_eligible** - `1` if the puzzle counts towards your NYT streak - this means you solved without cheating (checks or reveals) on the day of the puzzle before Midnight PST
+* **author** - The author(s) of the puzzle
+* **editor** - Almost always Will Shortz
+* **format_type** - Almost always "Normal"
+* **print_date** - Date the puzzle was published
+* **day_of_week_name** - Pretty name of the puzzle's day
+* **day_of_week_integer** - Integer value, Sunday = `0`, Monday = `1` ...
+* **publish_type** - `Normal`, `Mini`, `Bonus`
+* **puzzle_id** - NYT's reference ID for the puzzle
+* **title** - The puzzle's title (for Sundays)
+* **version** - NYT's version of the puzzle
+* **solved** - Whether the puzzle was solved
+* **star** - Gold if solved before midnight Pacific of its date (value available starting 2018-12-12 )
+* **solving_seconds** - how long it took to solve the puzzle
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Fetch your NYT Crossword Puzzle solve stats and export them as CSV.
 
 The NYT app shows minimal information around your streaks and average solve times. This gets you the raw data so you can do your own analysis.
 
-This version is a departure from its predecessor and uses new API endpoints published by the NYT. The data it produces does not line up tidily with the previous version.
 
 ## What's a GitHub?
 Not well-versed in Python or the command-line? Consider signing up for [XW Stats](https://xwstats.com). It's a free site that automatically fetches your solves and allows you to download them as a CSV.

--- a/fetch_puzzle_stats.py
+++ b/fetch_puzzle_stats.py
@@ -1,137 +1,170 @@
 import argparse
+import os
+import pickle
 from csv import DictWriter
 from datetime import datetime, timedelta
-import os
+import time
+
 import requests
+from dotenv import load_dotenv
 from tqdm import tqdm
 
-API_ROOT = 'https://nyt-games-prd.appspot.com/svc/crosswords'
-PUZZLE_INFO = API_ROOT + '/v2/puzzle/daily-{date}.json'
-SOLVE_INFO = API_ROOT + '/v2/game/{game_id}.json'
-DATE_FORMAT = '%Y-%m-%d'
+load_dotenv()
 
-parser = argparse.ArgumentParser(description='Fetch NYT Crossword stats')
+API_ROOT = "http://www.nytimes.com/svc/crosswords"
+PUZZLE_INFO = API_ROOT + "/v3/puzzles.json"
+PUZZLE_DETAIL = API_ROOT + "/v6/game/"
+
+DATE_FORMAT = "%Y-%m-%d"
+
+parser = argparse.ArgumentParser(description="Fetch NYT Crossword stats")
+parser.add_argument("-u", "--username", help="NYT Account Email Address")
+parser.add_argument("-p", "--password", help="NYT Account Password")
 parser.add_argument(
-    '-u', '--username', help='NYT Account Email Address')
-parser.add_argument(
-    '-p', '--password', help='NYT Account Password')
-parser.add_argument(
-    '-s', '--start-date',
-    help='The first date to pull from, inclusive (defaults to 30 days ago)',
-    default=datetime.strftime(datetime.now() - timedelta(days=30), DATE_FORMAT)
+    "-s",
+    "--start-date",
+    help="The first date to pull from, inclusive (defaults to 30 days ago)",
+    default=datetime.strftime(datetime.now() - timedelta(days=30), DATE_FORMAT),
 )
 parser.add_argument(
-    '-e', '--end-date',
-    help='The last date to pull from, inclusive (defaults to today)',
-    default=datetime.strftime(datetime.now(), DATE_FORMAT)
+    "-e",
+    "--end-date",
+    help="The last date to pull from, inclusive (defaults to today)",
+    default=datetime.strftime(datetime.now(), DATE_FORMAT),
 )
 parser.add_argument(
-    '-o', '--output-csv',
-    help='The CSV file to write to',
-    default='data.csv'
+    "-o", "--output-csv", help="The CSV file to write to", default="data.csv"
 )
 parser.add_argument(
-    '--strict',
-    help='Don\'t allow missing puzzles or errors',
-    action='store_true',
+    "-t",
+    "--type",
+    help='The type of puzzle data to fetch. Valid values are "daily", "bonus", and "mini" (defaults to daily)',
+    default="daily",
 )
 
 
 def login(username, password):
-    """ Return the NYT-S cookie after logging in """
+    """Return the NYT-S cookie after logging in"""
     login_resp = requests.post(
-        'https://myaccount.nytimes.com/svc/ios/v2/login',
+        "https://myaccount.nytimes.com/svc/ios/v2/login",
         data={
-            'login': username,
-            'password': password,
+            "login": username,
+            "password": password,
         },
         headers={
-            'User-Agent': 'Crosswords/20191213190708 CFNetwork/1128.0.1 Darwin/19.6.0',
-            'client_id': 'ios.crosswords',
+            "User-Agent": "Crosswords/20191213190708 CFNetwork/1128.0.1 Darwin/19.6.0",
+            "client_id": "ios.crosswords",
         },
     )
     login_resp.raise_for_status()
-    for cookie in login_resp.json()['data']['cookies']:
-        if cookie['name'] == 'NYT-S':
-            return cookie['cipheredValue']
-    raise ValueError('NYT-S cookie not found')
+    for cookie in login_resp.json()["data"]["cookies"]:
+        if cookie["name"] == "NYT-S":
+            return cookie["cipheredValue"]
+    raise ValueError("NYT-S cookie not found")
 
 
-def get_puzzle_stats(date, cookie):
-    puzzle_resp = requests.get(
-        PUZZLE_INFO.format(date=date),
-        cookies={
-            'NYT-S': cookie,
-        },
-    )
-    puzzle_resp.raise_for_status()
-    puzzle_date = datetime.strptime(date, DATE_FORMAT)
-    puzzle_info = puzzle_resp.json().get('results')[0]
-    solve_resp = requests.get(
-        SOLVE_INFO.format(game_id=puzzle_info['puzzle_id']),
-        cookies={
-            'NYT-S': cookie,
-        },
-    )
-    solve_resp.raise_for_status()
-    solve_info = solve_resp.json().get('results')
-
-    solved = solve_info.get('solved', False)
-    checked = 'firstChecked' in solve_info
-    revealed = 'firstRevealed' in solve_info
-    solve_date = datetime.fromtimestamp(solve_info.get('firstSolved', 0))
-    # A puzzle is streak eligible if they didn't cheat and they solved it
-    # before midnight PST (assume 8 hour offset for now, no DST)
-    streak_eligible = solved and not checked and not revealed and (
-        solve_date <= puzzle_date + timedelta(days=1) + timedelta(hours=8))
-
-    return {
-        'elapsed_seconds': solve_info.get('timeElapsed', 0),
-        'solved': int(solved),
-        'checked': int(checked),
-        'revealed': int(revealed),
-        'streak_eligible': int(streak_eligible),
+def get_v3_puzzle_overview(puzzle_type, start_date, end_date, cookie):
+    payload = {
+        "publish_type": puzzle_type,
+        "sort_order": "asc",
+        "sort_by": "print_date",
+        "date_start": start_date.strftime("%Y-%m-%d"),
+        "date_end": end_date.strftime("%Y-%m-%d"),
     }
 
+    overview_resp = requests.get(PUZZLE_INFO, params=payload, cookies={"NYT-S": cookie})
 
-if __name__ == '__main__':
+    overview_resp.raise_for_status()
+    puzzle_info = overview_resp.json().get("results")
+    return puzzle_info
+
+
+def get_v3_puzzle_detail(puzzle_id, cookie):
+    puzzle_resp = requests.get(
+        f"{PUZZLE_DETAIL}/{puzzle_id}.json", cookies={"NYT-S": cookie}
+    )
+
+    puzzle_resp.raise_for_status()
+    puzzle_detail = puzzle_resp.json()["calcs"]
+
+    # crude rate limiting
+    time.sleep(0.25)
+    return puzzle_detail
+
+
+if __name__ == "__main__":
     args = parser.parse_args()
-    cookie = os.getenv('NYT_COOKIE')
+    cookie = os.getenv("NYT_COOKIE")
     if not cookie:
         cookie = login(args.username, args.password)
+
     start_date = datetime.strptime(args.start_date, DATE_FORMAT)
     end_date = datetime.strptime(args.end_date, DATE_FORMAT)
-    print("Getting stats from {} until {}".format(
-        datetime.strftime(start_date, DATE_FORMAT),
-        datetime.strftime(end_date, DATE_FORMAT)))
-    date = start_date
-    fields = [
-        'date',
-        'day',
-        'elapsed_seconds',
-        'solved',
-        'checked',
-        'revealed',
-        'streak_eligible',
-    ]
-    with open(args.output_csv, 'w') as csvfile, \
-            tqdm(total=(end_date-start_date).days + 1) as pbar:
-        writer = DictWriter(csvfile, fields)
-        writer.writeheader()
-        count = 0
-        while date <= end_date:
-            date_str = datetime.strftime(date, DATE_FORMAT)
-            try:
-                solve = get_puzzle_stats(date_str, cookie)
-                solve['date'] = date_str
-                solve['day'] = datetime.strftime(date, '%a')
-                writer.writerow(solve)
-                count += 1
-            except Exception:
-                # Ignore missing puzzles errors in non-strict
-                if args.strict:
-                    raise
-            pbar.update(1)
-            date += timedelta(days=1)
 
-    print("{} rows written to {}".format(count, args.output_csv))
+    days_between = (end_date - start_date).days
+    batches = (days_between // 100) + 1
+
+    print(
+        f"Getting stats from {args.start_date} until {args.end_date} in {batches} batches"
+    )
+
+    date = start_date
+
+    if end_date - start_date > timedelta(days=100):
+        batch_end = start_date + timedelta(days=100)
+    else:
+        batch_end = end_date
+    batch_start = start_date
+
+    puzzle_overview = []
+
+    for batch in (pbar := tqdm(range(batches))):
+        pbar.set_description(f"Start date: {batch_start}")
+        batch_overview = get_v3_puzzle_overview(
+            puzzle_type=args.type,
+            start_date=batch_start,
+            end_date=batch_end,
+            cookie=cookie,
+        )
+        puzzle_overview.extend(batch_overview)
+        batch_start = batch_start + timedelta(days=100)
+        batch_end = batch_end + timedelta(days=100)
+
+    # A temporary file just in case it dies with those solve times
+    with open("tmp.pkl", "wb") as f:
+        pickle.dump(puzzle_overview, f)
+
+    print("\nGetting puzzle solve times\n")
+
+    for puzzle in tqdm(puzzle_overview):
+        detail = get_v3_puzzle_detail(puzzle_id=puzzle["puzzle_id"], cookie=cookie)
+        puzzle["solving_seconds"] = detail.get("secondsSpentSolving", None)
+        puzzle["day_of_week_name"] = datetime.strptime(puzzle["print_date"], DATE_FORMAT).strftime('%A')
+        puzzle["day_of_week_integer"] = datetime.strptime(puzzle["print_date"], DATE_FORMAT).strftime('%w')
+
+    fields = [
+        "author",
+        "editor",
+        "format_type",
+        "print_date",
+        "day_of_week_name",
+        "day_of_week_integer",
+        "publish_type",
+        "puzzle_id",
+        "title",
+        "version",
+        "percent_filled",
+        "solved",
+        "star",
+        "solving_seconds",
+    ]
+
+    print("Writing stats to {}".format(args.output_csv))
+
+    with open(args.output_csv, "w") as f:
+        writer = DictWriter(f, fields)
+        writer.writeheader()
+        writer.writerows(puzzle_overview)
+
+    os.remove("tmp.pkl")
+    print("{} rows written to {}".format(len(puzzle_overview), args.output_csv))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-tqdm
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
+tqdm
 python-dotenv


### PR DESCRIPTION
This branch was created after the v2 API threw too many errors to proceed.

It hits the v3 endpoints and brings back a somewhat different set of data. It continues to use the authentication logic in the original project.  I have added the ability to read the NYT cookie from a `.env` file to simplify that for users who must go that route.

Additionally, it is able to pull statistics for `daily`, `mini`, and `bonus` crosswords.

Documentation has been updated to reflect new data structures and additional command line parameters